### PR TITLE
Fixed xclip from losing copied emoji when launched throw a terminal t…

### DIFF
--- a/tuimoji/tuimoji.py
+++ b/tuimoji/tuimoji.py
@@ -32,7 +32,7 @@ class CustomSelectableIcon(urwid.SelectableIcon):
         return key
 
     def paste(self, contents):
-        p = Popen([shlex.split('nohup xclip -selection %s >/dev/null 2>&1' % self.selection)], stdin=PIPE)
+        p = Popen(['nohup', 'xclip', '-selection', self.selection, '> /dev/null 2>&1 &'], stdin=PIPE)
         p.communicate(contents)
 
 

--- a/tuimoji/tuimoji.py
+++ b/tuimoji/tuimoji.py
@@ -32,7 +32,7 @@ class CustomSelectableIcon(urwid.SelectableIcon):
         return key
 
     def paste(self, contents):
-        p = Popen(['xclip', '-selection', self.selection], stdin=PIPE)
+        p = Popen(['nohup', 'xclip', '-selection', self.selection], stdin=PIPE)
         p.communicate(contents)
 
 

--- a/tuimoji/tuimoji.py
+++ b/tuimoji/tuimoji.py
@@ -32,7 +32,7 @@ class CustomSelectableIcon(urwid.SelectableIcon):
         return key
 
     def paste(self, contents):
-        p = Popen(['nohup', 'xclip', '-selection', self.selection, '> /dev/null 2>&1 &'], stdin=PIPE)
+        p = Popen(['nohup', 'xclip', '-selection', self.selection, '&> /tmp/nohup.out'], stdin=PIPE)
         p.communicate(contents)
 
 

--- a/tuimoji/tuimoji.py
+++ b/tuimoji/tuimoji.py
@@ -32,7 +32,7 @@ class CustomSelectableIcon(urwid.SelectableIcon):
         return key
 
     def paste(self, contents):
-        p = Popen(['nohup', 'xclip', '-selection', self.selection], stdin=PIPE, stdout=subprocess.DEVNULL)
+        p = Popen(['nohup', 'xclip', '-selection', self.selection], stdin=PIPE, stderr=subprocess.STDOUT)
         p.communicate(contents)
 
 

--- a/tuimoji/tuimoji.py
+++ b/tuimoji/tuimoji.py
@@ -32,7 +32,7 @@ class CustomSelectableIcon(urwid.SelectableIcon):
         return key
 
     def paste(self, contents):
-        p = Popen(['nohup', 'xclip', '-selection', self.selection, '> /dev/null 2>&1&'], stdin=PIPE)
+        p = Popen(['nohup', 'xclip', '-selection', self.selection], shell=False, stdin=PIPE)
         p.communicate(contents)
 
 

--- a/tuimoji/tuimoji.py
+++ b/tuimoji/tuimoji.py
@@ -32,7 +32,7 @@ class CustomSelectableIcon(urwid.SelectableIcon):
         return key
 
     def paste(self, contents):
-        p = Popen(['nohup', 'xclip', '-selection', self.selection], shell=False, stdin=PIPE)
+        p = Popen([shlex.split('nohup xclip -selection %s >/dev/null 2>&1' % self.selection)], stdin=PIPE)
         p.communicate(contents)
 
 

--- a/tuimoji/tuimoji.py
+++ b/tuimoji/tuimoji.py
@@ -32,7 +32,7 @@ class CustomSelectableIcon(urwid.SelectableIcon):
         return key
 
     def paste(self, contents):
-        p = Popen(['nohup', 'xclip', '-selection', self.selection], stdin=PIPE)
+        p = Popen(['nohup', 'xclip', '-selection', self.selection, '>/dev/null 2>&1'], stdin=PIPE)
         p.communicate(contents)
 
 

--- a/tuimoji/tuimoji.py
+++ b/tuimoji/tuimoji.py
@@ -32,7 +32,7 @@ class CustomSelectableIcon(urwid.SelectableIcon):
         return key
 
     def paste(self, contents):
-        p = Popen(['nohup', 'xclip', '-selection', self.selection], stdin=PIPE, stderr=subprocess.STDOUT)
+        p = Popen(['nohup', 'xclip', '-selection', self.selection, '> /dev/null 2>&1&'], stdin=PIPE)
         p.communicate(contents)
 
 

--- a/tuimoji/tuimoji.py
+++ b/tuimoji/tuimoji.py
@@ -32,7 +32,7 @@ class CustomSelectableIcon(urwid.SelectableIcon):
         return key
 
     def paste(self, contents):
-        p = Popen(['nohup', 'xclip', '-selection', self.selection, '&> /tmp/nohup.out'], stdin=PIPE)
+        p = Popen(['xclip', '-selection', self.selection, '& disown'], stdin=PIPE)
         p.communicate(contents)
 
 

--- a/tuimoji/tuimoji.py
+++ b/tuimoji/tuimoji.py
@@ -32,7 +32,7 @@ class CustomSelectableIcon(urwid.SelectableIcon):
         return key
 
     def paste(self, contents):
-        p = Popen(['nohup', 'xclip', '-selection', self.selection, '>/dev/null 2>&1'], stdin=PIPE)
+        p = Popen(['nohup', 'xclip', '-selection', self.selection], stdin=PIPE, stdout=subprocess.DEVNULL)
         p.communicate(contents)
 
 


### PR DESCRIPTION
When launched through a hotkey through a terminal (-e) xclip loses the copied emoji. This fixes it.